### PR TITLE
feat: add validation for organization name length in AccountValidator

### DIFF
--- a/api/v1alpha1/account_webhook.go
+++ b/api/v1alpha1/account_webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,6 +46,11 @@ type AccountValidator struct {
 func (v *AccountValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	account := obj.(*Account)
 	if account.Spec.Type == AccountTypeOrg {
+
+		if len(strings.TrimSpace(account.Name)) < 3 {
+			return nil, fmt.Errorf("organization name %q is too short, must be at least 3 characters", account.Name)
+		}
+
 		if slices.Contains(v.DenyList, account.Name) {
 			return nil, fmt.Errorf("organization name %q is not allowed", account.Name)
 		}
@@ -56,6 +62,10 @@ func (v *AccountValidator) ValidateUpdate(ctx context.Context, oldObj, newObj ru
 	account := newObj.(*Account)
 
 	if account.Spec.Type == AccountTypeOrg {
+		if len(strings.TrimSpace(account.Name)) < 3 {
+			return nil, fmt.Errorf("organization name %q is too short, must be at least 3 characters", account.Name)
+		}
+
 		if slices.Contains(v.DenyList, account.Name) {
 			return nil, fmt.Errorf("organization name %q is not allowed", account.Name)
 		}

--- a/api/v1alpha1/account_webhook_test.go
+++ b/api/v1alpha1/account_webhook_test.go
@@ -53,6 +53,16 @@ func TestAccountValidator_ValidateCreate(t *testing.T) {
 			denyList:    []string{},
 			expectError: false,
 		},
+		{
+			name: "deny less than 3 characters",
+			account: &Account{
+				ObjectMeta: metav1.ObjectMeta{Name: "gk"},
+				Spec:       AccountSpec{Type: "org"},
+			},
+			denyList:    []string{},
+			expectError: true,
+			errorMsg:    `organization name "gk" is too short, must be at least 3 characters`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -171,6 +181,20 @@ func TestAccountValidator_ValidateUpdate(t *testing.T) {
 			},
 			denyList:    []string{},
 			expectError: false,
+		},
+		{
+			name: "deny less than 3 characters",
+			oldAccount: &Account{
+				ObjectMeta: metav1.ObjectMeta{Name: "gke"},
+				Spec:       AccountSpec{Type: "org"},
+			},
+			newAccount: &Account{
+				ObjectMeta: metav1.ObjectMeta{Name: "gk"},
+				Spec:       AccountSpec{Type: "org"},
+			},
+			denyList:    []string{},
+			expectError: true,
+			errorMsg:    `organization name "gk" is too short, must be at least 3 characters`,
 		},
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added validation for organization names: they must be at least 3 characters. This applies to both account creation and updates (e.g., renaming). Users will see a clear error message if the name is too short, helping prevent invalid entries and ensuring consistent naming standards across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->