### PR TITLE
feat: improve retry behavior with static-then-exponential rate limiter

### DIFF
--- a/pkg/subroutines/fga.go
+++ b/pkg/subroutines/fga.go
@@ -10,6 +10,7 @@ import (
 	kcpcorev1alpha "github.com/kcp-dev/kcp/sdk/apis/core/v1alpha1"
 	kcptenancyv1alpha "github.com/kcp-dev/kcp/sdk/apis/tenancy/v1alpha1"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/platform-mesh/golang-commons/controller/lifecycle/ratelimiter"
 	"github.com/platform-mesh/golang-commons/controller/lifecycle/runtimeobject"
 	"github.com/platform-mesh/golang-commons/errors"
 	"github.com/platform-mesh/golang-commons/fga/helpers"
@@ -22,7 +23,6 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	"github.com/platform-mesh/account-operator/api/v1alpha1"
-	"github.com/platform-mesh/account-operator/pkg/clusteredname"
 	"github.com/platform-mesh/account-operator/pkg/subroutines/accountinfo"
 )
 
@@ -33,24 +33,26 @@ type FGASubroutine struct {
 	parentRelation  string
 	creatorRelation string
 
-	limiter workqueue.TypedRateLimiter[clusteredname.ClusteredName]
+	limiter workqueue.TypedRateLimiter[*v1alpha1.Account]
 }
 
 func NewFGASubroutine(mgr mcmanager.Manager, fgaClient openfgav1.OpenFGAServiceClient, creatorRelation, parentRelation, objectType string) *FGASubroutine {
+	rcfg := ratelimiter.NewConfig()
+	rcfg.StaticWindow = 5 * time.Minute
+	rcfg.ExponentialMaxBackoff = 15 * time.Minute
+	limiter, _ := ratelimiter.NewStaticThenExponentialRateLimiter[*v1alpha1.Account](rcfg) //nolint:errcheck
 	return &FGASubroutine{
 		mgr:             mgr,
 		fgaClient:       fgaClient,
 		creatorRelation: creatorRelation,
 		parentRelation:  parentRelation,
 		objectType:      objectType,
-		limiter:         workqueue.NewTypedItemExponentialFailureRateLimiter[clusteredname.ClusteredName](1*time.Second, 120*time.Second),
+		limiter:         limiter,
 	}
 }
 
 func (e *FGASubroutine) Process(ctx context.Context, ro runtimeobject.RuntimeObject) (ctrl.Result, errors.OperatorError) {
 	account := ro.(*v1alpha1.Account)
-	cn := clusteredname.MustGetClusteredName(ctx, ro)
-
 	log := logger.LoadLoggerFromContext(ctx)
 	log.Debug().Msg("Starting creator subroutine process() function")
 
@@ -72,7 +74,7 @@ func (e *FGASubroutine) Process(ctx context.Context, ro runtimeobject.RuntimeObj
 
 	if accountWorkspace.Status.Phase != kcpcorev1alpha.LogicalClusterPhaseReady {
 		log.Info().Msg("workspace is not ready yet, retry")
-		return ctrl.Result{RequeueAfter: e.limiter.When(cn)}, nil
+		return ctrl.Result{RequeueAfter: e.limiter.When(account)}, nil
 	}
 
 	accountCluster, err := e.mgr.GetCluster(ctx, accountWorkspace.Spec.Cluster)
@@ -157,7 +159,7 @@ func (e *FGASubroutine) Process(ctx context.Context, ro runtimeobject.RuntimeObj
 		}
 	}
 
-	e.limiter.Forget(cn)
+	e.limiter.Forget(account)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
## Summary

- Replace exponential-only rate limiter with static-then-exponential rate limiter from golang-commons for FGA subroutine retries
- Configure 5-minute static window followed by exponential backoff up to 15 minutes max
- Simplify rate limiter key by using Account object directly instead of ClusteredName