### PR TITLE
fix: oidc info retrieval from parent account info 

### DIFF
--- a/pkg/subroutines/accountinfo/accountinfo.go
+++ b/pkg/subroutines/accountinfo/accountinfo.go
@@ -139,6 +139,7 @@ func (r *AccountInfoSubroutine) Process(ctx context.Context, ro runtimeobject.Ru
 		accountInfo.Spec.ParentAccount = &parentAccountInfo.Spec.Account
 		accountInfo.Spec.Organization = parentAccountInfo.Spec.Organization
 		accountInfo.Spec.FGA.Store.Id = parentAccountInfo.Spec.FGA.Store.Id
+		accountInfo.Spec.OIDC = parentAccountInfo.Spec.OIDC
 		accountInfo.Spec.ClusterInfo.CA = r.serverCA
 		return nil
 	})


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

This pr is related to https://github.com/platform-mesh/security-operator/issues/266