### PR TITLE
feat: upgrade KCP to v0.30.0 and controller-tools to v0.20.0

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,13 +3,13 @@ version: '3'
 vars:
   LOCAL_BIN: bin
   GOLANGCI_LINT_VERSION: v2.8.0
-  CONTROLLER_TOOLS_VERSION: v0.19.0
+  CONTROLLER_TOOLS_VERSION: v0.20.0
   ENVTEST_K8S_VERSION: "1.29.0"
   ENVTEST_VERSION: release-0.17
   CRD_DIRECTORY: config/crd
   TEST_SETUP_DIRECTORY: test/setup/01-platform-mesh-system
-  KCP_APIGEN_VERSION: v0.27.1
-  KCP_VERSION: 0.29.0
+  KCP_APIGEN_VERSION: v0.30.0
+  KCP_VERSION: 0.30.0
   GOMPLATE_VERSION: v4.3.0
   GOARCH:
     sh: go env GOARCH
@@ -36,7 +36,7 @@ tasks:
   setup:kcp-api-gen:
     internal: true
     cmds:
-      - test -s {{.LOCAL_BIN}}/apigen || GOBIN=$(pwd)/{{.LOCAL_BIN}} go install github.com/kcp-dev/kcp/sdk/cmd/apigen@{{.KCP_APIGEN_VERSION}}
+      - test -s {{.LOCAL_BIN}}/apigen || GOBIN=$(pwd)/{{.LOCAL_BIN}} go install github.com/kcp-dev/sdk/cmd/apigen@{{.KCP_APIGEN_VERSION}}
 
   ## Development
   manifests:

--- a/config/crd/core.platform-mesh.io_accountinfos.yaml
+++ b/config/crd/core.platform-mesh.io_accountinfos.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: accountinfos.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/config/crd/core.platform-mesh.io_accounts.yaml
+++ b/config/crd/core.platform-mesh.io_accounts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.0
   name: accounts.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/config/resources/apiexport-core.platform-mesh.io.yaml
+++ b/config/resources/apiexport-core.platform-mesh.io.yaml
@@ -1,21 +1,28 @@
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIExport
 metadata:
-  creationTimestamp: null
   name: core.platform-mesh.io
 spec:
-  latestResourceSchemas:
-  - v250915-1185c0b.accounts.core.platform-mesh.io
-  - v260126-7c674ee.accountinfos.core.platform-mesh.io
   permissionClaims:
-  - all: true
-    resource: namespaces
-  - all: true
-    group: tenancy.kcp.io
+  - resource: namespaces
+    verbs: null
+  - group: tenancy.kcp.io
     identityHash: '{{ .data.apiExportRootTenancyKcpIoIdentityHash }}'
     resource: workspaces
-  - all: true
-    group: tenancy.kcp.io
+    verbs: null
+  - group: tenancy.kcp.io
     identityHash: '{{ .data.apiExportRootTenancyKcpIoIdentityHash }}'
     resource: workspacetypes
+    verbs: null
+  resources:
+  - group: core.platform-mesh.io
+    name: accountinfos
+    schema: v260126-7c674ee.accountinfos.core.platform-mesh.io
+    storage:
+      crd: {}
+  - group: core.platform-mesh.io
+    name: accounts
+    schema: v260109-82344be.accounts.core.platform-mesh.io
+    storage:
+      crd: {}
 status: {}

--- a/config/resources/apiresourceschema-accountinfos.core.platform-mesh.io.yaml
+++ b/config/resources/apiresourceschema-accountinfos.core.platform-mesh.io.yaml
@@ -1,7 +1,6 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  creationTimestamp: null
   name: v260126-7c674ee.accountinfos.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/config/resources/apiresourceschema-accounts.core.platform-mesh.io.yaml
+++ b/config/resources/apiresourceschema-accounts.core.platform-mesh.io.yaml
@@ -1,7 +1,6 @@
 apiVersion: apis.kcp.io/v1alpha1
 kind: APIResourceSchema
 metadata:
-  creationTimestamp: null
   name: v260109-82344be.accounts.core.platform-mesh.io
 spec:
   group: core.platform-mesh.io

--- a/test/setup/01-platform-mesh-system/apiexport-core.platform-mesh.io.yaml
+++ b/test/setup/01-platform-mesh-system/apiexport-core.platform-mesh.io.yaml
@@ -1,21 +1,28 @@
-apiVersion: apis.kcp.io/v1alpha1
+apiVersion: apis.kcp.io/v1alpha2
 kind: APIExport
 metadata:
-  creationTimestamp: null
   name: core.platform-mesh.io
 spec:
-  latestResourceSchemas:
-  - v250715-5b899f6.accountinfos.core.platform-mesh.io
-  - v260109-82344be.accounts.core.platform-mesh.io
   permissionClaims:
-  - all: true
-    resource: namespaces
-  - all: true
-    group: tenancy.kcp.io
+  - resource: namespaces
+    verbs: null
+  - group: tenancy.kcp.io
     identityHash: '{{ .data.apiExportRootTenancyKcpIoIdentityHash }}'
     resource: workspaces
-  - all: true
-    group: tenancy.kcp.io
+    verbs: null
+  - group: tenancy.kcp.io
     identityHash: '{{ .data.apiExportRootTenancyKcpIoIdentityHash }}'
     resource: workspacetypes
+    verbs: null
+  resources:
+  - group: core.platform-mesh.io
+    name: accountinfos
+    schema: v260206-c3b6d8d.accountinfos.core.platform-mesh.io
+    storage:
+      crd: {}
+  - group: core.platform-mesh.io
+    name: accounts
+    schema: v260206-c3b6d8d.accounts.core.platform-mesh.io
+    storage:
+      crd: {}
 status: {}


### PR DESCRIPTION
## Summary

- Upgrade KCP version from 0.29.0 to 0.30.0
- Update KCP apigen version from v0.27.1 to v0.30.0
- Upgrade controller-tools version from v0.19.0 to v0.20.0
- Migrate APIExport from `apis.kcp.io/v1alpha1` to `v1alpha2` with new resource schema format
- Fix apigen install path for new `kcp/sdk` module structure