### PR TITLE
fix(deps): remove k8s.io replace directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,6 @@ module github.com/platform-mesh/account-operator
 
 go 1.25.7
 
-replace (
-	k8s.io/api => k8s.io/api v0.35.2
-	k8s.io/apimachinery => k8s.io/apimachinery v0.35.2
-	k8s.io/client-go => k8s.io/client-go v0.35.2
-)
-
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/kcp-dev/logicalcluster/v3 v3.0.5


### PR DESCRIPTION
## Summary

- Removes the `replace` directives for `k8s.io/api`, `k8s.io/apimachinery`, and `k8s.io/client-go` that are no longer needed
- The required versions (v0.35.2) resolve correctly without overrides, aligning with upstream `kcp-dev/multicluster-provider`