### PR TITLE
chore: add go-approvers team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # Default code owners
-* @platform-mesh/frame
+* @platform-mesh/frame @platform-mesh/go-approvers
 go.mod
 go.sum


### PR DESCRIPTION
Add @platform-mesh/go-approvers team to the CODEOWNERS catch-all rule.