### PR TITLE
feat: retrieve orgs client via manager

### DIFF
--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/kcp-dev/multicluster-provider/apiexport"
+	pathaware "github.com/kcp-dev/multicluster-provider/path-aware"
 	platformmeshcontext "github.com/platform-mesh/golang-commons/context"
 	"github.com/platform-mesh/golang-commons/traces"
 	"github.com/spf13/cobra"
@@ -96,7 +97,7 @@ func RunController(_ *cobra.Command, _ []string) { // coverage-ignore
 			log.Fatal().Err(err).Msg("unable to get in-cluster config")
 		}
 	}
-	provider, err := apiexport.New(restCfg, operatorCfg.Kcp.ApiExportEndpointSliceName, apiexport.Options{
+	provider, err := pathaware.New(restCfg, operatorCfg.Kcp.ApiExportEndpointSliceName, apiexport.Options{
 		Log:    &ctrl.Log,
 		Scheme: scheme,
 	})

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -123,12 +123,7 @@ func RunController(_ *cobra.Command, _ []string) { // coverage-ignore
 		log.Fatal().Err(err).Msg("unable to start manager")
 	}
 
-	orgsClient, err := buildOrgsClient(mgr.GetLocalManager())
-	if err != nil {
-		log.Fatal().Err(err).Msg("unable to create orgs client")
-	}
-
-	accountReconciler, err := controller.NewAccountReconciler(log, mgr, operatorCfg, orgsClient)
+	accountReconciler, err := controller.NewAccountReconciler(log, mgr, operatorCfg)
 	if err != nil {
 		log.Fatal().Err(err).Msg("unable to create account reconciler")
 	}

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/kcp-dev/multicluster-provider/apiexport"
@@ -31,7 +30,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -173,22 +171,4 @@ func RunController(_ *cobra.Command, _ []string) { // coverage-ignore
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		log.Fatal().Err(err).Msg("problem running manager")
 	}
-}
-
-func buildOrgsClient(mgr ctrl.Manager) (client.Client, error) {
-	cfg := rest.CopyConfig(mgr.GetConfig())
-
-	parsed, err := url.Parse(cfg.Host)
-	if err != nil {
-		log.Error().Err(err).Msg("unable to parse host")
-		return nil, err
-	}
-
-	parsed.Path = "/clusters/root:orgs"
-
-	cfg.Host = parsed.String()
-
-	return client.New(cfg, client.Options{
-		Scheme: scheme,
-	})
 }

--- a/internal/controller/account_controller.go
+++ b/internal/controller/account_controller.go
@@ -42,7 +42,7 @@ type AccountReconciler struct {
 	rateLimiter workqueue.TypedRateLimiter[mcreconcile.Request]
 }
 
-func NewAccountReconciler(log *logger.Logger, mgr mcmanager.Manager, cfg config.OperatorConfig, orgsClient client.Client) (*AccountReconciler, error) {
+func NewAccountReconciler(log *logger.Logger, mgr mcmanager.Manager, cfg config.OperatorConfig) (*AccountReconciler, error) {
 	localMgr := mgr.GetLocalManager()
 	localCfg := rest.CopyConfig(localMgr.GetConfig())
 	serverCA := string(localCfg.CAData)
@@ -50,11 +50,11 @@ func NewAccountReconciler(log *logger.Logger, mgr mcmanager.Manager, cfg config.
 	subs := []subroutines.Subroutine{}
 
 	if cfg.Subroutines.WorkspaceType.Enabled {
-		subs = append(subs, workspacetype.New(orgsClient))
+		subs = append(subs, workspacetype.New(mgr))
 	}
 
 	if cfg.Subroutines.Workspace.Enabled {
-		wsSub, err := workspace.New(mgr, orgsClient)
+		wsSub, err := workspace.New(mgr)
 		if err != nil {
 			return nil, fmt.Errorf("creating Workspace subroutine: %w", err)
 		}

--- a/internal/controller/account_controller_setup_test.go
+++ b/internal/controller/account_controller_setup_test.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"time"
 
-	apiexport "github.com/kcp-dev/multicluster-provider/apiexport"
+	"github.com/kcp-dev/multicluster-provider/apiexport"
 	mcc "github.com/kcp-dev/multicluster-provider/client"
 	"github.com/kcp-dev/multicluster-provider/envtest"
+	pathaware "github.com/kcp-dev/multicluster-provider/path-aware"
 	kcpapisv1alpha1 "github.com/kcp-dev/sdk/apis/apis/v1alpha1"
 	kcpapisv1alpha2 "github.com/kcp-dev/sdk/apis/apis/v1alpha2"
 	"github.com/kcp-dev/sdk/apis/core"
@@ -179,7 +180,7 @@ func (s *AccountTestSuite) setupManager() {
 	providerConfig.Host += fmt.Sprintf("/clusters/%s", s.platformMeshSysPath)
 
 	axplogr := s.logger.ComponentLogger("apiexport_provider").Logr()
-	provider, err := apiexport.New(providerConfig, "core.platform-mesh.io", apiexport.Options{
+	provider, err := pathaware.New(providerConfig, "core.platform-mesh.io", apiexport.Options{
 		Scheme: s.scheme,
 		Log:    &axplogr,
 	})

--- a/internal/controller/account_controller_test.go
+++ b/internal/controller/account_controller_test.go
@@ -100,7 +100,7 @@ func (s *AccountTestSuite) SetupSuite() {
 	cfg.Subroutines.WorkspaceType.Enabled = true
 	cfg.Kcp.ProviderWorkspace = core.RootCluster.Path().String()
 	dCfg := &platformmeshconfig.CommonServiceConfig{}
-	accountReconciler, err := controller.NewAccountReconciler(logger, s.mgr, cfg, s.rootOrgsClient)
+	accountReconciler, err := controller.NewAccountReconciler(logger, s.mgr, cfg)
 	s.Require().NoError(err)
 	s.Require().NoError(accountReconciler.SetupWithManager(s.mgr, dCfg, logger))
 	s.startManager()

--- a/pkg/subroutines/workspace/workspace.go
+++ b/pkg/subroutines/workspace/workspace.go
@@ -8,6 +8,7 @@ import (
 	conditionsapi "github.com/kcp-dev/sdk/apis/third_party/conditions/apis/conditions/v1alpha1"
 	conditionshelper "github.com/kcp-dev/sdk/apis/third_party/conditions/util/conditions"
 	"github.com/platform-mesh/golang-commons/controller/lifecycle/ratelimiter"
+	"github.com/platform-mesh/golang-commons/logger"
 	"github.com/platform-mesh/subroutines"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -33,21 +34,19 @@ const (
 )
 
 type WorkspaceSubroutine struct {
-	mgr        mcmanager.Manager
-	limiter    workqueue.TypedRateLimiter[*v1alpha1.Account]
-	orgsClient client.Client
+	mgr     mcmanager.Manager
+	limiter workqueue.TypedRateLimiter[*v1alpha1.Account]
 }
 
-func New(mgr mcmanager.Manager, orgsClient client.Client) (*WorkspaceSubroutine, error) {
+func New(mgr mcmanager.Manager) (*WorkspaceSubroutine, error) {
 	rl, err := ratelimiter.NewStaticThenExponentialRateLimiter[*v1alpha1.Account](
 		ratelimiter.NewConfig())
 	if err != nil {
 		return nil, fmt.Errorf("creating RateLimiter: %w", err)
 	}
 	return &WorkspaceSubroutine{
-		mgr:        mgr,
-		limiter:    rl,
-		orgsClient: orgsClient,
+		mgr:     mgr,
+		limiter: rl,
 	}, nil
 }
 
@@ -149,8 +148,16 @@ func (r *WorkspaceSubroutine) Process(ctx context.Context, obj client.Object) (s
 // TODO: could potentially work without the orgsClient when we look up the
 // orgs workspaceid on startup
 func (r *WorkspaceSubroutine) checkWorkspaceTypeReady(ctx context.Context, workspaceTypeName string) (bool, error) {
+	cluster, err := r.mgr.GetCluster(ctx, orgsWorkspacePath)
+	if err != nil {
+		return false, err
+	}
+	clusterClient := cluster.GetClient()
+
+	log := logger.LoadLoggerFromContext(ctx)
+	log.Info().Msg("Getting workspace using retrieved client")
 	wst := &kcptenancyv1alpha.WorkspaceType{}
-	if err := r.orgsClient.Get(ctx, client.ObjectKey{Name: workspaceTypeName}, wst); err != nil {
+	if err := clusterClient.Get(ctx, client.ObjectKey{Name: workspaceTypeName}, wst); err != nil {
 		if kerrors.IsNotFound(err) {
 			return false, nil
 		}

--- a/pkg/subroutines/workspace/workspace_test.go
+++ b/pkg/subroutines/workspace/workspace_test.go
@@ -24,13 +24,13 @@ import (
 )
 
 func TestGetName(t *testing.T) {
-	s, err := workspace.New(nil, nil)
+	s, err := workspace.New(nil)
 	require.NoError(t, err)
 	assert.Equal(t, workspace.WorkspaceSubroutineName, s.GetName())
 }
 
 func TestFinalizers(t *testing.T) {
-	s, err := workspace.New(nil, nil)
+	s, err := workspace.New(nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{workspace.WorkspaceSubroutineFinalizer}, s.Finalizers(nil))
 }
@@ -109,7 +109,7 @@ func TestFinalize(t *testing.T) {
 				test.k8sMocks(client)
 			}
 
-			s, err := workspace.New(mgr, nil)
+			s, err := workspace.New(mgr)
 			require.NoError(t, err)
 
 			ctx := t.Context()
@@ -268,24 +268,32 @@ func TestProcess(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			mgr := mocks.NewManager(t)
+			cluster := mocks.NewCluster(t)
+			orgsCluster := mocks.NewCluster(t)
 			orgsClient := mocks.NewClient(t)
+
 			if test.orgsK8sMocks != nil {
 				test.orgsK8sMocks(orgsClient)
 			}
 
-			mgr := mocks.NewManager(t)
-			cluster := mocks.NewCluster(t)
-
-			mgr.EXPECT().GetCluster(mock.Anything, mock.Anything).Return(cluster, nil)
+			mgr.EXPECT().
+				GetCluster(mock.Anything, "root:orgs").
+				Return(orgsCluster, nil).
+				Maybe()
+			mgr.EXPECT().
+				GetCluster(mock.Anything, mock.Anything).
+				Return(cluster, nil)
 
 			client := mocks.NewClient(t)
 			cluster.EXPECT().GetClient().Return(client)
+			orgsCluster.EXPECT().GetClient().Return(orgsClient).Maybe()
 
 			if test.k8sMocks != nil {
 				test.k8sMocks(client)
 			}
 
-			s, err := workspace.New(mgr, orgsClient)
+			s, err := workspace.New(mgr)
 			require.NoError(t, err)
 
 			ctx := t.Context()

--- a/pkg/subroutines/workspacetype/workspace_type.go
+++ b/pkg/subroutines/workspacetype/workspace_type.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	"github.com/platform-mesh/account-operator/api/v1alpha1"
 	"github.com/platform-mesh/account-operator/pkg/subroutines/util"
@@ -31,12 +32,12 @@ const (
 )
 
 type WorkspaceTypeSubroutine struct {
-	orgsClient client.Client
+	mgr mcmanager.Manager
 }
 
-func New(orgsClient client.Client) *WorkspaceTypeSubroutine {
+func New(mgr mcmanager.Manager) *WorkspaceTypeSubroutine {
 	return &WorkspaceTypeSubroutine{
-		orgsClient: orgsClient,
+		mgr: mgr,
 	}
 }
 
@@ -68,8 +69,14 @@ func (w *WorkspaceTypeSubroutine) Process(ctx context.Context, obj client.Object
 }
 
 func (w *WorkspaceTypeSubroutine) createOrPatchWorkspaceType(ctx context.Context, desiredWst kcptenancyv1alpha.WorkspaceType) error {
+	orgsCluster, err := w.mgr.GetCluster(ctx, orgsWorkspacePath)
+	if err != nil {
+		return err
+	}
+	orgsClusterClient := orgsCluster.GetClient()
+
 	wst := &kcptenancyv1alpha.WorkspaceType{ObjectMeta: metav1.ObjectMeta{Name: desiredWst.Name}}
-	_, err := controllerutil.CreateOrPatch(ctx, w.orgsClient, wst, func() error {
+	_, err = controllerutil.CreateOrPatch(ctx, orgsClusterClient, wst, func() error {
 		if wst.Labels == nil {
 			wst.Labels = make(map[string]string)
 		}
@@ -91,17 +98,23 @@ func (w *WorkspaceTypeSubroutine) Finalize(ctx context.Context, obj client.Objec
 		return subroutines.OK(), nil
 	}
 
+	orgsCluster, err := w.mgr.GetCluster(ctx, "root:orgs")
+	if err != nil {
+		return subroutines.OK(), err
+	}
+	orgsClusterClient := orgsCluster.GetClient()
+
 	orgWorkspaceTypeName := util.GetWorkspaceTypeName(instance.Name, instance.Spec.Type)
 	accountWorkspaceTypeName := util.GetWorkspaceTypeName(instance.Name, v1alpha1.AccountTypeAccount)
 
-	if err := w.orgsClient.Delete(ctx, &kcptenancyv1alpha.WorkspaceType{ObjectMeta: metav1.ObjectMeta{Name: orgWorkspaceTypeName}}); err != nil {
+	if err := orgsClusterClient.Delete(ctx, &kcptenancyv1alpha.WorkspaceType{ObjectMeta: metav1.ObjectMeta{Name: orgWorkspaceTypeName}}); err != nil {
 		if !kerrors.IsNotFound(err) {
 			log.Error().Err(err).Str("name", orgWorkspaceTypeName).Msg("failed to delete org workspace type")
 			return subroutines.OK(), err
 		}
 	}
 
-	if err := w.orgsClient.Delete(ctx, &kcptenancyv1alpha.WorkspaceType{ObjectMeta: metav1.ObjectMeta{Name: accountWorkspaceTypeName}}); err != nil {
+	if err := orgsClusterClient.Delete(ctx, &kcptenancyv1alpha.WorkspaceType{ObjectMeta: metav1.ObjectMeta{Name: accountWorkspaceTypeName}}); err != nil {
 		if !kerrors.IsNotFound(err) {
 			log.Error().Err(err).Str("name", accountWorkspaceTypeName).Msg("failed to delete account workspace type")
 			return subroutines.OK(), err

--- a/pkg/subroutines/workspacetype/workspace_type_test.go
+++ b/pkg/subroutines/workspacetype/workspace_type_test.go
@@ -91,13 +91,16 @@ func TestFinalize(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-
 			cl := mocks.NewClient(t)
+			cluster := mocks.NewCluster(t)
+			mgr := mocks.NewManager(t)
 			if test.k8sMocks != nil {
 				test.k8sMocks(cl)
 			}
+			mgr.EXPECT().GetCluster(mock.Anything, "root:orgs").Return(cluster, nil)
+			cluster.EXPECT().GetClient().Return(cl)
 
-			s := workspacetype.New(cl)
+			s := workspacetype.New(mgr)
 
 			ctx := t.Context()
 
@@ -145,11 +148,15 @@ func TestProcess(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			cl := mocks.NewClient(t)
+			cluster := mocks.NewCluster(t)
+			mgr := mocks.NewManager(t)
 			if test.k8sMocks != nil {
 				test.k8sMocks(cl)
 			}
+			mgr.EXPECT().GetCluster(mock.Anything, "root:orgs").Return(cluster, nil).Twice()
+			cluster.EXPECT().GetClient().Return(cl).Twice()
 
-			s := workspacetype.New(cl)
+			s := workspacetype.New(mgr)
 
 			_, processErr := s.Process(t.Context(), test.obj)
 			if test.expectError {
@@ -187,7 +194,12 @@ func TestProcess_PreservesAuthenticationConfigurations(t *testing.T) {
 		WithObjects(existingOrgWst, existingAccWst).
 		Build()
 
-	s := workspacetype.New(fakeClient)
+	cluster := mocks.NewCluster(t)
+	mgr := mocks.NewManager(t)
+	mgr.EXPECT().GetCluster(mock.Anything, "root:orgs").Return(cluster, nil).Twice()
+	cluster.EXPECT().GetClient().Return(fakeClient).Twice()
+
+	s := workspacetype.New(mgr)
 
 	account := &v1alpha1.Account{
 		ObjectMeta: metav1.ObjectMeta{Name: "test"},


### PR DESCRIPTION
On-behalf-of: @SAP <simon@simontesar.com>

Switches to the `pathaware`-Provider and retrieves the `root:orgs`-client via manager. 