### PR TITLE
test: add CRD roundtrip and webhook fuzz tests

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,6 +79,16 @@ tasks:
     cmds:
       - "{{ .LOCAL_BIN}}/kcp start"
 
+  fuzz:
+    desc: "Run fuzz tests with a configurable duration (default 30s per target)"
+    vars:
+      FUZZTIME: '{{.FUZZTIME | default "30s"}}'
+    cmds:
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzAccountRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzAccountInfoRoundTrip -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzAccountValidateCreate -fuzztime={{.FUZZTIME}} -count=1
+      - go test ./api/v1alpha1/ -run=^$ -fuzz=FuzzAccountValidateUpdate -fuzztime={{.FUZZTIME}} -count=1
+
   docker:kind:
     desc: "Build container image with current tag from kind cluster and load it"
     vars:

--- a/api/v1alpha1/roundtrip_fuzz_test.go
+++ b/api/v1alpha1/roundtrip_fuzz_test.go
@@ -1,0 +1,53 @@
+package v1alpha1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func FuzzAccountRoundTrip(f *testing.F) {
+	f.Add([]byte(`{"apiVersion":"core.platform-mesh.io/v1alpha1","kind":"Account","metadata":{"name":"test"},"spec":{"type":"org","displayName":"Test"}}`))
+	f.Add([]byte(`{"spec":{"type":"account","displayName":"a","description":"desc","creator":"user","extensions":[{"apiVersion":"v1","kind":"Ext","specGoTemplate":{}}]}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &Account{}, &Account{})
+	})
+}
+
+func FuzzAccountInfoRoundTrip(f *testing.F) {
+	f.Add([]byte(`{"apiVersion":"core.platform-mesh.io/v1alpha1","kind":"AccountInfo","metadata":{"name":"test"},"spec":{"fga":{"store":{"id":"s1"}},"account":{"name":"a","generatedClusterId":"c1","originClusterId":"c2","path":"/p","url":"https://example.com","type":"org"},"organization":{"name":"o","generatedClusterId":"c3","originClusterId":"c4","path":"/o","url":"https://example.com","type":"org"},"clusterInfo":{"ca":"cert"}}}`))
+	f.Add([]byte(`{"spec":{"fga":{"store":{"id":""}},"account":{"name":"","generatedClusterId":"","originClusterId":"","path":"","url":"","type":""},"organization":{"name":"","generatedClusterId":"","originClusterId":"","path":"","url":"","type":""},"clusterInfo":{"ca":""},"oidc":{"issuerUrl":"https://auth.example.com","clients":{"app1":{"clientId":"c1"}}}}}`))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fuzzRoundTrip(t, data, &AccountInfo{}, &AccountInfo{})
+	})
+}
+
+// fuzzRoundTrip unmarshals arbitrary JSON into obj, marshals it back, unmarshals
+// into obj2, and checks semantic equality. We use equality.Semantic.DeepEqual from
+// k8s.io/apimachinery which treats nil and empty slices/maps as equivalent — the
+// standard Kubernetes comparison semantic for API objects.
+func fuzzRoundTrip[T any](t *testing.T, data []byte, obj *T, obj2 *T) {
+	t.Helper()
+
+	if err := json.Unmarshal(data, obj); err != nil {
+		return
+	}
+
+	roundtripped, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	if err := json.Unmarshal(roundtripped, obj2); err != nil {
+		t.Fatalf("failed to unmarshal roundtripped data: %v", err)
+	}
+
+	if !equality.Semantic.DeepEqual(obj, obj2) {
+		t.Errorf("roundtrip mismatch for %T", obj)
+	}
+}

--- a/api/v1alpha1/webhook_fuzz_test.go
+++ b/api/v1alpha1/webhook_fuzz_test.go
@@ -1,0 +1,77 @@
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func FuzzAccountValidateCreate(f *testing.F) {
+	f.Add("my-org", "org", "admin,root,system")
+	f.Add("ab", "org", "")
+	f.Add("", "", "blocked")
+	f.Add("valid-name", "account", "")
+	f.Add("a", "unknown-type", "a")
+
+	f.Fuzz(func(t *testing.T, name, accountType, denyListCSV string) {
+		var denyList []string
+		if denyListCSV != "" {
+			denyList = splitCSV(denyListCSV)
+		}
+
+		account := &Account{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       AccountSpec{Type: AccountType(accountType)},
+		}
+		validator := &AccountValidator{
+			OrganizationNameDenyList: denyList,
+			AccountTypeAllowList:     []AccountType{AccountTypeAccount, AccountTypeOrg},
+		}
+
+		// Must not panic — validation errors are expected
+		_, _ = validator.ValidateCreate(context.Background(), account)
+	})
+}
+
+func FuzzAccountValidateUpdate(f *testing.F) {
+	f.Add("old-org", "org", "new-org", "org", "admin,root")
+	f.Add("admin", "account", "admin", "org", "admin")
+	f.Add("", "", "", "", "")
+
+	f.Fuzz(func(t *testing.T, oldName, oldType, newName, newType, denyListCSV string) {
+		var denyList []string
+		if denyListCSV != "" {
+			denyList = splitCSV(denyListCSV)
+		}
+
+		oldAccount := &Account{
+			ObjectMeta: metav1.ObjectMeta{Name: oldName},
+			Spec:       AccountSpec{Type: AccountType(oldType)},
+		}
+		newAccount := &Account{
+			ObjectMeta: metav1.ObjectMeta{Name: newName},
+			Spec:       AccountSpec{Type: AccountType(newType)},
+		}
+		validator := &AccountValidator{
+			OrganizationNameDenyList: denyList,
+			AccountTypeAllowList:     []AccountType{AccountTypeAccount, AccountTypeOrg},
+		}
+
+		// Must not panic — validation errors are expected
+		_, _ = validator.ValidateUpdate(context.Background(), oldAccount, newAccount)
+	})
+}
+
+func splitCSV(s string) []string {
+	var result []string
+	start := 0
+	for i := range len(s) {
+		if s[i] == ',' {
+			result = append(result, s[start:i])
+			start = i + 1
+		}
+	}
+	result = append(result, s[start:])
+	return result
+}


### PR DESCRIPTION
## Summary

- Add Go native fuzz tests for `Account` and `AccountInfo` CRD types that verify JSON serialization roundtrip fidelity using `k8s.io/apimachinery/pkg/api/equality`
- Add fuzz tests for `AccountValidator.ValidateCreate` and `ValidateUpdate` that ensure validators never panic on arbitrary input
- Add `task fuzz` to Taskfile with configurable `FUZZTIME` (default 30s per target)

Seed corpus runs as regular unit tests during `go test ./...` — no CI changes needed.

Closes #219
Ref platform-mesh/backlog#231