### PR TITLE
Add custom Prometheus metrics

### DIFF
--- a/api/v1alpha1/account_webhook.go
+++ b/api/v1alpha1/account_webhook.go
@@ -11,6 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	mcruntime "sigs.k8s.io/multicluster-runtime"
+
+	"github.com/platform-mesh/account-operator/internal/metrics"
 )
 
 func SetupAccountWebhookWithManager(mgr ctrl.Manager, organizationNameDenyList []string, accountTypeAllowList []AccountType) error {
@@ -47,45 +49,57 @@ type AccountValidator struct {
 
 func (v *AccountValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	account := obj.(*Account)
+	accountType := string(account.Spec.Type)
 
 	if !slices.Contains(v.AccountTypeAllowList, account.Spec.Type) {
+		metrics.WebhookValidations.WithLabelValues("create", "denied", accountType).Inc()
 		return nil, fmt.Errorf("account type %s not in allowlist", account.Spec.Type)
 	}
 
 	if account.Spec.Type != AccountTypeOrg {
+		metrics.WebhookValidations.WithLabelValues("create", "allowed", accountType).Inc()
 		return nil, nil
 	}
 
 	if len(strings.TrimSpace(account.Name)) < 3 {
+		metrics.WebhookValidations.WithLabelValues("create", "denied", accountType).Inc()
 		return nil, fmt.Errorf("organization name %q is too short, must be at least 3 characters", account.Name)
 	}
 
 	if slices.Contains(v.OrganizationNameDenyList, account.Name) {
+		metrics.WebhookValidations.WithLabelValues("create", "denied", accountType).Inc()
 		return nil, fmt.Errorf("organization name %q is not allowed", account.Name)
 	}
 
+	metrics.WebhookValidations.WithLabelValues("create", "allowed", accountType).Inc()
 	return nil, nil
 }
 
 func (v *AccountValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	account := newObj.(*Account)
+	accountType := string(account.Spec.Type)
 
 	if !slices.Contains(v.AccountTypeAllowList, account.Spec.Type) {
+		metrics.WebhookValidations.WithLabelValues("update", "denied", accountType).Inc()
 		return nil, fmt.Errorf("account type %s not in allowlist", account.Spec.Type)
 	}
 
 	if account.Spec.Type != AccountTypeOrg {
+		metrics.WebhookValidations.WithLabelValues("update", "allowed", accountType).Inc()
 		return nil, nil
 	}
 
 	if len(strings.TrimSpace(account.Name)) < 3 {
+		metrics.WebhookValidations.WithLabelValues("update", "denied", accountType).Inc()
 		return nil, fmt.Errorf("organization name %q is too short, must be at least 3 characters", account.Name)
 	}
 
 	if slices.Contains(v.OrganizationNameDenyList, account.Name) {
+		metrics.WebhookValidations.WithLabelValues("update", "denied", accountType).Inc()
 		return nil, fmt.Errorf("organization name %q is not allowed", account.Name)
 	}
 
+	metrics.WebhookValidations.WithLabelValues("update", "allowed", accountType).Inc()
 	return nil, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kcp-dev/sdk v0.31.0
 	github.com/platform-mesh/golang-commons v0.16.5
 	github.com/platform-mesh/subroutines v0.3.3
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -50,6 +51,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kcp-dev/apimachinery/v2 v2.31.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/martinlindhe/base36 v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
@@ -59,7 +61,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/gomega v1.38.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/controller/account_controller.go
+++ b/internal/controller/account_controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/platform-mesh/account-operator/api/v1alpha1"
 	"github.com/platform-mesh/account-operator/internal/config"
+	"github.com/platform-mesh/account-operator/internal/metrics"
 	"github.com/platform-mesh/account-operator/pkg/subroutines/manageaccountinfo"
 	"github.com/platform-mesh/account-operator/pkg/subroutines/workspace"
 	"github.com/platform-mesh/account-operator/pkg/subroutines/workspaceready"
@@ -40,6 +41,7 @@ type AccountReconciler struct {
 	cfg         config.OperatorConfig
 	lifecycle   *lifecycle.Lifecycle
 	rateLimiter workqueue.TypedRateLimiter[mcreconcile.Request]
+	mgr         mcmanager.Manager
 }
 
 func NewAccountReconciler(log *logger.Logger, mgr mcmanager.Manager, cfg config.OperatorConfig) (*AccountReconciler, error) {
@@ -90,6 +92,7 @@ func NewAccountReconciler(log *logger.Logger, mgr mcmanager.Manager, cfg config.
 		cfg:         cfg,
 		lifecycle:   lc,
 		rateLimiter: rl,
+		mgr:         mgr,
 	}, nil
 }
 
@@ -108,5 +111,23 @@ func (r *AccountReconciler) SetupWithManager(mgr mcmanager.Manager, cfg *platfor
 }
 
 func (r *AccountReconciler) Reconcile(ctx context.Context, req mcreconcile.Request) (ctrl.Result, error) {
-	return r.lifecycle.Reconcile(ctx, req)
+	accountType := "unknown"
+
+	if clusterRef, err := r.mgr.GetCluster(ctx, req.ClusterName); err == nil {
+		account := &v1alpha1.Account{}
+		if err := clusterRef.GetClient().Get(ctx, req.NamespacedName, account); err == nil {
+			accountType = string(account.Spec.Type)
+		}
+	}
+
+	result, err := r.lifecycle.Reconcile(ctx, req)
+	switch {
+	case err != nil:
+		metrics.AccountsReconciled.WithLabelValues(accountType, "error").Inc()
+	case result.RequeueAfter > 0:
+		metrics.AccountsReconciled.WithLabelValues(accountType, "requeue").Inc()
+	default:
+		metrics.AccountsReconciled.WithLabelValues(accountType, "success").Inc()
+	}
+	return result, err
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	AccountsReconciled = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "account_operator_accounts_reconciled_total",
+			Help: "Total number of Account reconcile calls by type and result.",
+		},
+		[]string{"type", "result"},
+	)
+	WebhookValidations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "account_operator_webhook_validations_total",
+			Help: "Total number of Account webhook validation requests.",
+		},
+		[]string{"operation", "result", "account_type"},
+	)
+	WorkspaceReadyDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "account_operator_workspace_ready_duration_seconds",
+			Help:    "Time from Account creation to Workspace reaching Ready phase.",
+			Buckets: []float64{1, 5, 10, 30, 60, 120, 300},
+		},
+		[]string{"type"},
+	)
+	WorkspaceTypeOperations = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "account_operator_workspacetype_operations_total",
+			Help: "Total number of WorkspaceType create or update operations performed for organizations.",
+		},
+		[]string{"operation", "wst_kind"},
+	)
+	OrgProvisioningDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "account_operator_org_provisioning_duration_seconds",
+			Help:    "Time from organization Account creation to its AccountInfo being written.",
+			Buckets: []float64{1, 5, 10, 30, 60, 120, 300},
+		},
+		[]string{},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		AccountsReconciled,
+		WebhookValidations,
+		WorkspaceReadyDuration,
+		WorkspaceTypeOperations,
+		OrgProvisioningDuration,
+	)
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,90 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/platform-mesh/account-operator/internal/metrics"
+)
+
+type MetricsTestSuite struct {
+	suite.Suite
+}
+
+func TestMetricsTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsTestSuite))
+}
+
+// TestAccountsReconciled verifies that the AccountsReconciled counter increments
+// correctly for each label combination (type, result). It captures the value
+// before and after a simulated increment and asserts the counter increased by 1.
+func (s *MetricsTestSuite) TestAccountsReconciled() {
+	before := testutil.ToFloat64(metrics.AccountsReconciled.WithLabelValues("org", "success"))
+	metrics.AccountsReconciled.WithLabelValues("org", "success").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.AccountsReconciled.WithLabelValues("org", "success")))
+
+	before = testutil.ToFloat64(metrics.AccountsReconciled.WithLabelValues("org", "error"))
+	metrics.AccountsReconciled.WithLabelValues("org", "error").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.AccountsReconciled.WithLabelValues("org", "error")))
+
+	before = testutil.ToFloat64(metrics.AccountsReconciled.WithLabelValues("account", "requeue"))
+	metrics.AccountsReconciled.WithLabelValues("account", "requeue").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.AccountsReconciled.WithLabelValues("account", "requeue")))
+}
+
+// TestWebhookValidations verifies that the WebhookValidations counter increments
+// correctly for each label combination (operation, result, account_type). It covers
+// allowed and denied outcomes for both create and update webhook calls.
+func (s *MetricsTestSuite) TestWebhookValidations() {
+	before := testutil.ToFloat64(metrics.WebhookValidations.WithLabelValues("create", "allowed", "org"))
+	metrics.WebhookValidations.WithLabelValues("create", "allowed", "org").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.WebhookValidations.WithLabelValues("create", "allowed", "org")))
+
+	before = testutil.ToFloat64(metrics.WebhookValidations.WithLabelValues("create", "denied", "org"))
+	metrics.WebhookValidations.WithLabelValues("create", "denied", "org").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.WebhookValidations.WithLabelValues("create", "denied", "org")))
+
+	before = testutil.ToFloat64(metrics.WebhookValidations.WithLabelValues("update", "allowed", "account"))
+	metrics.WebhookValidations.WithLabelValues("update", "allowed", "account").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.WebhookValidations.WithLabelValues("update", "allowed", "account")))
+}
+
+// TestWorkspaceReadyDuration verifies that the WorkspaceReadyDuration histogram
+// records observations. It checks that the number of collected series increases
+// after observing durations for both org and account workspace types.
+func (s *MetricsTestSuite) TestWorkspaceReadyDuration() {
+	before := testutil.CollectAndCount(metrics.WorkspaceReadyDuration)
+	metrics.WorkspaceReadyDuration.WithLabelValues("org").Observe(12.5)
+	metrics.WorkspaceReadyDuration.WithLabelValues("org").Observe(45.0)
+	metrics.WorkspaceReadyDuration.WithLabelValues("account").Observe(8.3)
+	s.Assert().Greater(testutil.CollectAndCount(metrics.WorkspaceReadyDuration), before)
+}
+
+// TestOrgProvisioningDuration verifies that the OrgProvisioningDuration histogram
+// records observations. It checks that the number of collected series increases
+// after observing two provisioning durations.
+func (s *MetricsTestSuite) TestOrgProvisioningDuration() {
+	before := testutil.CollectAndCount(metrics.OrgProvisioningDuration)
+	metrics.OrgProvisioningDuration.WithLabelValues().Observe(30.0)
+	metrics.OrgProvisioningDuration.WithLabelValues().Observe(75.0)
+	s.Assert().Greater(testutil.CollectAndCount(metrics.OrgProvisioningDuration), before)
+}
+
+// TestWorkspaceTypeOperations verifies that the WorkspaceTypeOperations counter
+// increments correctly for each label combination (operation, wst_kind). It covers
+// created and updated operations for both org and account workspace types.
+func (s *MetricsTestSuite) TestWorkspaceTypeOperations() {
+	before := testutil.ToFloat64(metrics.WorkspaceTypeOperations.WithLabelValues("created", "org"))
+	metrics.WorkspaceTypeOperations.WithLabelValues("created", "org").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.WorkspaceTypeOperations.WithLabelValues("created", "org")))
+
+	before = testutil.ToFloat64(metrics.WorkspaceTypeOperations.WithLabelValues("created", "account"))
+	metrics.WorkspaceTypeOperations.WithLabelValues("created", "account").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.WorkspaceTypeOperations.WithLabelValues("created", "account")))
+
+	before = testutil.ToFloat64(metrics.WorkspaceTypeOperations.WithLabelValues("updated", "org"))
+	metrics.WorkspaceTypeOperations.WithLabelValues("updated", "org").Inc()
+	s.Require().Equal(before+1, testutil.ToFloat64(metrics.WorkspaceTypeOperations.WithLabelValues("updated", "org")))
+}

--- a/pkg/subroutines/manageaccountinfo/manage_accountinfo.go
+++ b/pkg/subroutines/manageaccountinfo/manage_accountinfo.go
@@ -19,6 +19,7 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	"github.com/platform-mesh/account-operator/api/v1alpha1"
+	"github.com/platform-mesh/account-operator/internal/metrics"
 	"github.com/platform-mesh/account-operator/pkg/clusteredname"
 )
 
@@ -111,6 +112,8 @@ func (r *ManageAccountInfoSubroutine) Process(ctx context.Context, obj client.Ob
 		}
 
 		r.limiter.Forget(instance)
+		duration := time.Since(instance.CreationTimestamp.Time).Seconds()
+		metrics.OrgProvisioningDuration.WithLabelValues().Observe(duration)
 		return subroutines.OK(), nil
 	}
 

--- a/pkg/subroutines/workspaceready/workspaceready.go
+++ b/pkg/subroutines/workspaceready/workspaceready.go
@@ -3,6 +3,7 @@ package workspaceready
 import (
 	"context"
 	"fmt"
+	"time"
 
 	kcpcorev1alpha "github.com/kcp-dev/sdk/apis/core/v1alpha1"
 	kcptenancyv1alpha "github.com/kcp-dev/sdk/apis/tenancy/v1alpha1"
@@ -13,6 +14,7 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	"github.com/platform-mesh/account-operator/api/v1alpha1"
+	"github.com/platform-mesh/account-operator/internal/metrics"
 	"github.com/platform-mesh/account-operator/pkg/clusteredname"
 )
 
@@ -66,5 +68,9 @@ func (r *WorkspaceReadySubroutine) Process(ctx context.Context, obj client.Objec
 	}
 
 	r.limiter.Forget(instance)
+
+	duration := time.Since(instance.CreationTimestamp.Time).Seconds()
+	metrics.WorkspaceReadyDuration.WithLabelValues(string(instance.Spec.Type)).Observe(duration)
+
 	return subroutines.OK(), nil
 }

--- a/pkg/subroutines/workspacetype/workspace_type.go
+++ b/pkg/subroutines/workspacetype/workspace_type.go
@@ -14,6 +14,7 @@ import (
 	mcmanager "sigs.k8s.io/multicluster-runtime/pkg/manager"
 
 	"github.com/platform-mesh/account-operator/api/v1alpha1"
+	"github.com/platform-mesh/account-operator/internal/metrics"
 	"github.com/platform-mesh/account-operator/pkg/subroutines/util"
 )
 
@@ -55,12 +56,12 @@ func (w *WorkspaceTypeSubroutine) Process(ctx context.Context, obj client.Object
 	orgWst := generateOrgWorkspaceType(orgWorkspaceTypeName, accountWorkspaceTypeName, instance.Name)
 	accWst := generateAccountWorkspaceType(orgWorkspaceTypeName, accountWorkspaceTypeName, instance.Name)
 
-	if err := w.createOrPatchWorkspaceType(ctx, orgWst); err != nil {
+	if err := w.createOrPatchWorkspaceType(ctx, orgWst, "org"); err != nil {
 		log.Error().Err(err).Str("name", orgWst.Name).Msg("failed to create or update org workspace type")
 		return subroutines.OK(), err
 	}
 
-	if err := w.createOrPatchWorkspaceType(ctx, accWst); err != nil {
+	if err := w.createOrPatchWorkspaceType(ctx, accWst, "account"); err != nil {
 		log.Error().Err(err).Str("name", accWst.Name).Msg("failed to create or update account workspace type")
 		return subroutines.OK(), err
 	}
@@ -68,7 +69,7 @@ func (w *WorkspaceTypeSubroutine) Process(ctx context.Context, obj client.Object
 	return subroutines.OK(), nil
 }
 
-func (w *WorkspaceTypeSubroutine) createOrPatchWorkspaceType(ctx context.Context, desiredWst kcptenancyv1alpha.WorkspaceType) error {
+func (w *WorkspaceTypeSubroutine) createOrPatchWorkspaceType(ctx context.Context, desiredWst kcptenancyv1alpha.WorkspaceType, wstKind string) error {
 	orgsCluster, err := w.mgr.GetCluster(ctx, orgsWorkspacePath)
 	if err != nil {
 		return err
@@ -76,7 +77,7 @@ func (w *WorkspaceTypeSubroutine) createOrPatchWorkspaceType(ctx context.Context
 	orgsClusterClient := orgsCluster.GetClient()
 
 	wst := &kcptenancyv1alpha.WorkspaceType{ObjectMeta: metav1.ObjectMeta{Name: desiredWst.Name}}
-	_, err = controllerutil.CreateOrPatch(ctx, orgsClusterClient, wst, func() error {
+	result, err := controllerutil.CreateOrPatch(ctx, orgsClusterClient, wst, func() error {
 		if wst.Labels == nil {
 			wst.Labels = make(map[string]string)
 		}
@@ -88,7 +89,11 @@ func (w *WorkspaceTypeSubroutine) createOrPatchWorkspaceType(ctx context.Context
 		wst.Spec.LimitAllowedChildren = desiredWst.Spec.LimitAllowedChildren
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	metrics.WorkspaceTypeOperations.WithLabelValues(string(result), wstKind).Inc()
+	return nil
 }
 
 func (w *WorkspaceTypeSubroutine) Finalize(ctx context.Context, obj client.Object) (subroutines.Result, error) {


### PR DESCRIPTION
Added five custom metrics:

- `account_operator_accounts_reconciled_total` - counter, labels: type, result
  (success/error/requeue). Incremented on every Reconcile call.

- `account_operator_webhook_validations_total` - counter, labels: operation,
  result, account_type. Incremented at every allowed/denied path in the
  admission webhook.

- `account_operator_workspace_ready_duration_seconds` - histogram, label: type.
  Measures time from Account creation to Workspace reaching Ready phase.

- `account_operator_workspacetype_operations_total` - counter, labels: operation
  (created/updated), wst_kind (org/account). Tracks WorkspaceType create and
  patch operations performed for organizations.

- `account_operator_org_provisioning_duration_seconds` - histogram. Measures
  time from org Account creation to its AccountInfo being written.