### PR TITLE
Fix GHA permissions inheritance

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -6,13 +6,11 @@ on:
       - opened
       - synchronize
 
-permissions:
-  contents: read
-
 jobs:
   auto-labeler:
     if: github.event.pull_request.head.repo.full_name == github.repository
     uses: platform-mesh/.github/.github/workflows/job-auto-labeler.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
     permissions:
+      contents: read
       pull-requests: write
       issues: write

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -1,16 +1,16 @@
 name: OpenSSF Scorecard
 on:
-    push:
-        branches: [main]
-    schedule:
-        - cron: '30 4 * * 1'
-    workflow_dispatch:
-
-permissions: read-all
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 4 * * 1'
+  workflow_dispatch:
 
 jobs:
-    scorecard:
-        uses: platform-mesh/.github/.github/workflows/job-ossf-scorecard.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
-        permissions:
-            security-events: write
-            id-token: write
+  scorecard:
+    uses: platform-mesh/.github/.github/workflows/job-ossf-scorecard.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
     needs: [create-version, docker-build-push]
     uses: platform-mesh/.github/.github/workflows/job-sbom.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
     permissions:
+      contents: read
       packages: read
     with:
       imageReference: ghcr.io/platform-mesh/account-operator:${{ needs.create-version.outputs.version }}
@@ -66,6 +67,7 @@ jobs:
     uses: platform-mesh/.github/.github/workflows/job-image-ocm.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
     secrets: inherit
     permissions:
+      contents: read
       packages: write
     with:
       imageReference: ghcr.io/platform-mesh/account-operator:${{ needs.create-version.outputs.version }}


### PR DESCRIPTION
GitHub Actions does not merge workflow-level `permissions` into job-level `permissions` — defining a `permissions` block on a job fully overrides the workflow-level one, and any scope not listed defaults to `none`.

As a result, the affected jobs were running without the read scopes they relied on from the workflow level, since their job-level blocks only declared the write scopes they needed.

This PR explicitly adds the required read scopes to the job-level blocks so the reusable workflows have the permissions they actually need.