### PR TITLE
Fix missing top-level permissions in GitHub Actions

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -6,6 +6,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   auto-labeler:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -6,6 +6,9 @@ on:
     - cron: '30 4 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scorecard:
     uses: platform-mesh/.github/.github/workflows/job-ossf-scorecard.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0


### PR DESCRIPTION
The top-level permissions somehow got lost in two workflows, this is affecting the Scorecard score.